### PR TITLE
Fix text for light terminals

### DIFF
--- a/dockermake/utils/display.py
+++ b/dockermake/utils/display.py
@@ -8,7 +8,7 @@ except ImportError:
     HAS_TERMCOLOR = False
 
 
-def info(msg, color="white", end="\n"):
+def info(msg, color=None, end="\n"):
     print(_try_color(msg, color), end=end)
 
 


### PR DESCRIPTION
Most terminals use a dark background with light text color, in which case the default text color should be similar (if not identical) to the one defined as ANSI `white`.

If, however, your terminal is set to a light color scheme, the text is set to a dark color, similar (if not identical) to the one defined in ANSI `black`. In that case, without this fix, `docker-make` outputs white text on a light background, which is a little hard to read. All other colors are (based on your terminal color scheme) fine though.

I hence suggest we use the default text color instead of white for info messages, which should have almost no visible effect for regular dark terminals but enables the proper readability for light terminals.

**Note**: The build failed for me due to https://github.com/JonathonReinhart/staticx/issues/71#issuecomment-812719843, so as discussed, we wait until that is fixed upstream before we continue with this PR.